### PR TITLE
Providing immutable default value in Shape @dataclass

### DIFF
--- a/game.py
+++ b/game.py
@@ -148,7 +148,7 @@ class Shape:
     depth: int
     offset: int
     in_front_of: str = ""
-    style: Style = Style()
+    style: Style = field(default_factory=Style)
 
 
 @dataclass


### PR DESCRIPTION
When I tried to run the project with Python 3.11.5 I'd get the following error:

```
$ python3 game.py ~/storage/git/llama.cpp/main ~/storage/git/llama.cpp/models/somemodel.gguf prompt.txt 
Traceback (most recent call last):
  File "/home/user/storage/git/llama-journey/game.py", line 144, in <module>
    @dataclass
     ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1230, in dataclass
    return wrap(cls)
           ^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 1220, in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 958, in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/dataclasses.py", line 815, in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
ValueError: mutable default <class '__main__.Style'> for field style is not allowed: use default_factory
```

I changed the field to use a default_factory of Style and it seems to have resolved it (though I'm encountering another error that prevents me from testing game functionality beyond moving and equipping an item)